### PR TITLE
match parser should not return empty fields

### DIFF
--- a/app/src/main/java/com/ricardosfp/zapping/domain/match/MatchParserImpl.kt
+++ b/app/src/main/java/com/ricardosfp/zapping/domain/match/MatchParserImpl.kt
@@ -31,8 +31,11 @@ class MatchParserImpl @Inject constructor(
                         val awayTeam = teams[1]
                         val channel = parts[2]
 
-                        MatchParseSuccess(Match(homeTeam, awayTeam, date, channel, originalText))
-
+                        if (homeTeam.isEmpty() || awayTeam.isEmpty() || channel.isEmpty()) {
+                            MatchParseTitleError
+                        } else {
+                            MatchParseSuccess(Match(homeTeam, awayTeam, date, channel, originalText))
+                        }
                     } else {
                         // not two teams
                         // todo report this error


### PR DESCRIPTION
MatchParser should not yield success when at least one of home team, away team or channel fields are empty